### PR TITLE
Update activerecord-enhancedsqlite3-adapter.gemspec

### DIFF
--- a/activerecord-enhancedsqlite3-adapter.gemspec
+++ b/activerecord-enhancedsqlite3-adapter.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord", ">= 7.1"
-  spec.add_dependency "sqlite3", "~> 1.6"
+  spec.add_dependency "sqlite3", ">= 1.6", "<=2.0"
 
   spec.add_development_dependency "combustion", "~> 1.3"
   spec.add_development_dependency "railties"


### PR DESCRIPTION
Now sqlite3 2.0.0 is published. Time to update depedency